### PR TITLE
useEffectで文字起こしをfetchする

### DIFF
--- a/analyze/src/utils/pdf_utils.py
+++ b/analyze/src/utils/pdf_utils.py
@@ -38,7 +38,7 @@ def get_text(pdf_data: bytes) -> dict:
     doc = fitz.open(stream=pdf_data, filetype="pdf")
     text = {}
     try:
-        for i, page in enumerate(doc):
+        for i, page in enumerate(doc, start=1):
             text[i] = page.get_text()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"PDF解析エラー: {str(e)}")

--- a/front/src/app/analysis/page.tsx
+++ b/front/src/app/analysis/page.tsx
@@ -35,7 +35,7 @@ import {
   getAllFilesInfoFromFirebase,
   getFileFromStorage,
   addAdvice,
-  // getTranscription, // コメントアウト
+  getTranscription, // コメントアウト
 } from '@/app/firebase/form/fileInfo';
 
 import { StoredFileInfo } from "@/app/types/file-info.type"
@@ -156,11 +156,18 @@ const AnalysisPage = () => {
     const fetchTextAndTranscription = async () => {
       if (analysisData && !extractedText && !textLoading && mainFileInfo) {
         await performGetText();
-        await createDummyTranscriptions(); // getTranscriptionをコメントアウトし、ダミーを使用
+        // await createDummyTranscriptions(); // getTranscriptionをコメントアウトし、ダミーを使用
       }
     };
     fetchTextAndTranscription();
   }, [analysisData]);
+
+  useEffect(() => {
+    const runCreateDummyTranscriptions = async () => {
+      await createDummyTranscriptions(); 
+    };
+    runCreateDummyTranscriptions();
+  }, [extractedText]);
 
   useEffect(() => {
     setLoading(false);
@@ -252,13 +259,13 @@ const AnalysisPage = () => {
 
   // getTranscriptionをコメントアウトし、ダミー文字起こしを作成
   const createDummyTranscriptions = async () => {
-    if (!extractedText) return;
+    if (!extractedText || !mainFileInfo) return;
     const pages = Object.keys(extractedText);
     const tempMap: TranscriptionMap = {};
     for (const pageNum of pages) {
-      // const transcriptionText = await getTranscription(mainFileInfo.id, pageNum);
-      // tempMap[pageNum] = transcriptionText;
-      tempMap[pageNum] = `Dummy transcription for page ${pageNum}`;
+      const transcriptionText = await getTranscription(mainFileInfo.id, pageNum);
+      tempMap[pageNum] = transcriptionText;
+      // tempMap[pageNum] = `Dummy transcription for page ${pageNum}`;
     }
     setTranscriptions(tempMap);
   };
@@ -266,7 +273,7 @@ const AnalysisPage = () => {
   // analyze-presentation: extractedText + ダミーtranscriptionsをまとめて送信
   const performAnalyzePresentation = async () => {
     if (!extractedText) return;
-    try {
+    try {      
       const presentationsdata: any = {};
       Object.entries(extractedText).forEach(([page, text]) => {
         presentationsdata[page] = {


### PR DESCRIPTION
* FastAPIから返す値は，スライドの1ページ目を"0"としていたが，firebaseへの文字起こしはスライドをの1ページ目を"1"としていたので，FastAPIも1からにした
* `extractedText`に依存して，`creatgeDummyTranscription`が呼び出されるようにした
